### PR TITLE
Исправлена ошибка при индексации

### DIFF
--- a/core/components/msearch2/processors/mgr/index/create.class.php
+++ b/core/components/msearch2/processors/mgr/index/create.class.php
@@ -176,8 +176,9 @@ class mseIndexCreateProcessor extends modProcessor {
 		if (!empty($words)) {
 			$rows = array();
 			foreach ($words as $word => $fields) {
+				$word = $this->modx->quote($word);
 				foreach ($fields as $field => $count) {
-					$rows[] = "({$resource_id}, '{$field}', '{$word}', '{$count}', '{$class_key}')";
+					$rows[] = "({$resource_id}, '{$field}', {$word}, '{$count}', '{$class_key}')";
 				}
 			}
 			$sql .= "INSERT INTO {$tword} (`resource`, `field`, `word`, `count`, `class_key`) VALUES " . implode(',', $rows);
@@ -187,6 +188,13 @@ class mseIndexCreateProcessor extends modProcessor {
 		$q = $this->modx->prepare($sql);
 		if (!$q->execute()) {
 			$this->modx->log(modX::LOG_LEVEL_ERROR, '[mSearch2] Could not save search index of resource '.$resource_id.': '.print_r($q->errorInfo(),1));
+		} else {
+			while ($q->nextRowset()) {
+			}
+			$error = $q->errorInfo();
+			if ($error[0] !== '00000') {
+				$this->modx->log(modX::LOG_LEVEL_ERROR, '[mSearch2] Could not save search index of resource '.$resource_id.': '.print_r($error,1));
+			}
 		}
 	}
 


### PR DESCRIPTION
Если `$word` будет содержать одинарную кавычку, ресурс не будет добавлен в поисковый индекс. При этом ошибка не будет отображена в логе, поскольку `$q->execute()` вернет `true`, если первый запрос из списка был выполнен успешно.